### PR TITLE
add missing comments for exported types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/elh/bitempura.svg)](https://pkg.go.dev/github.com/elh/bitempura)
 [![Build Status](https://github.com/elh/bitempura/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/elh/bitempura/actions/workflows/go.yml?query=branch%3Amain)
+[![Go Report Card](https://goreportcard.com/badge/github.com/elh/bitempura)](https://goreportcard.com/report/github.com/elh/bitempura)
 
 **Bitempura.DB is a simple, [in-memory](https://github.com/elh/bitempura/blob/main/memory/db.go), [bitemporal](https://en.wikipedia.org/wiki/Bitemporal_Modeling) key-value database.**
 

--- a/db.go
+++ b/db.go
@@ -23,6 +23,7 @@ type DB interface {
 	History(key string) ([]*VersionedKV, error)
 }
 
+// WriteOptions is a struct for processing WriteOpt's to be used by DB
 type WriteOptions struct {
 	ValidTime    time.Time
 	EndValidTime *time.Time
@@ -45,6 +46,7 @@ func WithEndValidTime(t time.Time) WriteOpt {
 	}
 }
 
+// ReadOptions is a struct for processing ReadOpt's to be used by DB
 type ReadOptions struct {
 	ValidTime time.Time
 	TxTime    time.Time

--- a/errors.go
+++ b/errors.go
@@ -2,4 +2,5 @@ package bitempura
 
 import "errors"
 
+// ErrNotFound error is returned when key not found in DB (as of relevant valid and transaction times).
 var ErrNotFound = errors.New("not found")

--- a/memory/db.go
+++ b/memory/db.go
@@ -30,6 +30,7 @@ func NewDB(versionedKVs ...*bt.VersionedKV) (*DB, error) {
 	return db, nil
 }
 
+// DB is an in-memory, bitemporal key-value database.
 type DB struct {
 	now  *time.Time
 	vKVs map[string][]*bt.VersionedKV // key -> all versioned key-values with the key


### PR DESCRIPTION
~might remove golint on build but in general I do like the enforcement about comments on exported types which doesn't seem on in golangci-lint by default and too lazy to find it.~

don't want to include or install it during build. ignore for now