### PR TITLE
SQL.DB interface and Select() implementation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,3 +29,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.33.0 # elh: my current version
+          args: --timeout 5m

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# SQLite files
+*.db

--- a/db.go
+++ b/db.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// DB for bitemporal data.
+// DB is a key-value database for bitemporal data.
 //
 // Temporal control options.
 // ReadOpt's: AsOfValidTime, AsOfTransactionTime.

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,15 @@ module github.com/elh/bitempura
 
 go 1.17
 
-require github.com/stretchr/testify v1.7.0
+require (
+	github.com/Masterminds/squirrel v1.5.2
+	github.com/stretchr/testify v1.7.0
+)
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.10 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,16 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/Masterminds/squirrel v1.5.2 h1:UiOEi2ZX4RCSkpiNDQN5kro/XIBpSRk9iTqdIRPzUXE=
+github.com/Masterminds/squirrel v1.5.2/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
+github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
+github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,14 @@ github.com/Masterminds/squirrel v1.5.2/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA4
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
+github.com/mattn/go-sqlite3 v1.14.10 h1:MLn+5bFRlWMGoSRmJour3CL1w/qL96mvipqpwQW/Sfk=
+github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/memory/db.go
+++ b/memory/db.go
@@ -12,7 +12,7 @@ import (
 
 var _ bt.DB = (*DB)(nil)
 
-// NewDB constructs a in-memory bitemporal DB.
+// NewDB constructs a in-memory, bitemporal key-value database.
 //
 // The database may optionally be seeded with "versioned key-value" records. No two records for the same key may overlap
 // both transaction time and valid time. Transaction times (which normally default to now) may optionally be controlled

--- a/sql/db.go
+++ b/sql/db.go
@@ -39,7 +39,7 @@ func (db *TableDB) Get(key string, opts ...bt.ReadOpt) (*bt.VersionedKV, error) 
 	// SELECT *
 	// FROM <table>
 	// WHERE
-	// 		<the pk> = <key> AND
+	// 		<base table pk> = <key> AND
 	//		$tx_time_start <= <as_of_tx_time> AND
 	//		($tx_time_end IS NULL OR $tx_time_end > <as_of_tx_time>) AND
 	//		$valid_time_start <= <as_of_valid_time> AND
@@ -53,7 +53,7 @@ func (db *TableDB) List(opts ...bt.ReadOpt) ([]*bt.VersionedKV, error) {
 	// SELECT *
 	// FROM <table>
 	// WHERE
-	// 		<the pk> = <key> AND
+	// 		<base table pk> = <key> AND
 	//		$tx_time_start <= <as_of_tx_time> AND
 	//		($tx_time_end IS NULL OR $tx_time_end > <as_of_tx_time>) AND
 	//		$valid_time_start <= <as_of_valid_time> AND
@@ -84,7 +84,7 @@ func (db *TableDB) History(key string) ([]*bt.VersionedKV, error) {
 	// SELECT *
 	// FROM <table>
 	// WHERE
-	// 		<the pk> = <key>
+	// 		<base table pk> = <key>
 	return nil, errors.New("unimplemented")
 }
 

--- a/sql/db.go
+++ b/sql/db.go
@@ -12,6 +12,7 @@ import (
 var _ DB = (*TableDB)(nil)
 
 // DB is a SQL-backed, SQL-queryable, bitemporal database.
+// WARNING: WIP. this implementation is experimental.
 type DB interface {
 	bt.DB
 	// Select executes a SQL query (as of optional valid and transaction times).
@@ -19,6 +20,7 @@ type DB interface {
 }
 
 // NewTableDB constructs a SQL-backed, SQL-queryable, bitemporal database connected to a specific underlying SQL table.
+// WARNING: WIP. this implementation is experimental.
 func NewTableDB(eq ExecerQueryer, table string, pkColumnName string) (DB, error) {
 	// TODO: support composite PK through a pkFn(key string) Key struct
 	return &TableDB{
@@ -36,6 +38,7 @@ type TableDB struct {
 }
 
 // Get data by key (as of optional valid and transaction times).
+// WARNING: unimplemented
 func (db *TableDB) Get(key string, opts ...bt.ReadOpt) (*bt.VersionedKV, error) {
 	// SELECT *
 	// FROM <table>
@@ -50,6 +53,7 @@ func (db *TableDB) Get(key string, opts ...bt.ReadOpt) (*bt.VersionedKV, error) 
 }
 
 // List all data (as of optional valid and transaction times).
+// WARNING: unimplemented
 func (db *TableDB) List(opts ...bt.ReadOpt) ([]*bt.VersionedKV, error) {
 	// SELECT *
 	// FROM <table>
@@ -63,6 +67,7 @@ func (db *TableDB) List(opts ...bt.ReadOpt) ([]*bt.VersionedKV, error) {
 }
 
 // Set stores value (with optional start and end valid time).
+// WARNING: unimplemented
 func (db *TableDB) Set(key string, value bt.Value, opts ...bt.WriteOpt) error {
 	// INSERT
 	// INTO <table>
@@ -75,12 +80,14 @@ func (db *TableDB) Set(key string, value bt.Value, opts ...bt.WriteOpt) error {
 }
 
 // Delete removes value (with optional start and end valid time).
+// WARNING: unimplemented
 func (db *TableDB) Delete(key string, opts ...bt.WriteOpt) error {
 	// select out the conflicting records based on the write opt times. update them and add new ones as needed
 	return errors.New("unimplemented")
 }
 
 // History returns versions by descending end transaction time, descending end valid time
+// WARNING: unimplemented
 func (db *TableDB) History(key string) ([]*bt.VersionedKV, error) {
 	// SELECT *
 	// FROM <table>

--- a/sql/db.go
+++ b/sql/db.go
@@ -1,0 +1,101 @@
+package sql
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/Masterminds/squirrel"
+	bt "github.com/elh/bitempura"
+)
+
+var _ DB = (*TableDB)(nil)
+
+// DB is a SQL-backed, SQL-queryable, bitemporal database.
+type DB interface {
+	bt.DB
+	// Select executes a SQL query (as of optional valid and transaction times).
+	Select(query squirrel.SelectBuilder, opts ...bt.ReadOpt) (*sql.Rows, error)
+}
+
+// NewTableDB constructs a SQL-backed, SQL-queryable, bitemporal database connected to a specific underlying SQL table.
+func NewTableDB(eq ExecerQueryer, table string, pkColumnName string) (DB, error) {
+	// TODO: support composite PK through a pkFn(key string) Key struct
+	return &TableDB{
+		eq:           eq,
+		table:        table,
+		pkColumnName: pkColumnName,
+	}, nil
+}
+
+// TableDB is a SQL-backed, SQL-queryable, bitemporal database that is connected to a specific underlying SQL table.
+type TableDB struct {
+	eq           ExecerQueryer
+	table        string
+	pkColumnName string
+}
+
+// Get data by key (as of optional valid and transaction times).
+func (db *TableDB) Get(key string, opts ...bt.ReadOpt) (*bt.VersionedKV, error) {
+	// SELECT *
+	// FROM <table>
+	// WHERE
+	// 		<the pk> = <key> AND
+	//		$tx_time_start <= <as_of_tx_time> AND
+	//		($tx_time_end IS NULL OR $tx_time_end > <as_of_tx_time>) AND
+	//		$valid_time_start <= <as_of_valid_time> AND
+	//		($valid_time_end IS NULL OR $valid_time_end > <as_of_valid_time>)
+	// LIMIT 1
+	return nil, errors.New("unimplemented")
+}
+
+// List all data (as of optional valid and transaction times).
+func (db *TableDB) List(opts ...bt.ReadOpt) ([]*bt.VersionedKV, error) {
+	// SELECT *
+	// FROM <table>
+	// WHERE
+	// 		<the pk> = <key> AND
+	//		$tx_time_start <= <as_of_tx_time> AND
+	//		($tx_time_end IS NULL OR $tx_time_end > <as_of_tx_time>) AND
+	//		$valid_time_start <= <as_of_valid_time> AND
+	//		($valid_time_end IS NULL OR $valid_time_end > <as_of_valid_time>)
+	return nil, errors.New("unimplemented")
+}
+
+// Set stores value (with optional start and end valid time).
+func (db *TableDB) Set(key string, value bt.Value, opts ...bt.WriteOpt) error {
+	// INSERT
+	// INTO <table>
+	// (<fields...>, $tx_time_start, $tx_time_end, $valid_time_start, $valid_time_end)
+	// VALUES
+	// (<values...>, <tx_time_start>, <tx_time_end>, <valid_time_start>, <valid_time_end>)
+	//
+	// select out the conflicting records based on the write opt times. update them and add new ones as needed
+	return errors.New("unimplemented")
+}
+
+// Delete removes value (with optional start and end valid time).
+func (db *TableDB) Delete(key string, opts ...bt.WriteOpt) error {
+	// select out the conflicting records based on the write opt times. update them and add new ones as needed
+	return errors.New("unimplemented")
+}
+
+// History returns versions by descending end transaction time, descending end valid time
+func (db *TableDB) History(key string) ([]*bt.VersionedKV, error) {
+	// SELECT *
+	// FROM <table>
+	// WHERE
+	// 		<the pk> = <key>
+	return nil, errors.New("unimplemented")
+}
+
+// Select executes a SQL query (as of optional valid and transaction times).
+func (db *TableDB) Select(b squirrel.SelectBuilder, opts ...bt.ReadOpt) (*sql.Rows, error) {
+	return nil, errors.New("unimplemented")
+}
+
+// ExecerQueryer can Exec or Query. Both sql.DB and sql.Tx satisfy this interface.
+type ExecerQueryer interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
+}

--- a/sql/db_test.go
+++ b/sql/db_test.go
@@ -1,0 +1,165 @@
+package sql_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/elh/bitempura/sql"
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+// let's get a early POC of bitemporal SQL querying
+func TestQueryPOC(t *testing.T) {
+	file := "bitempura_test.db"
+	err := os.Remove(file)
+	var pathErr *os.PathError
+	require.True(t, err == nil || errors.As(err, &pathErr), err)
+
+	sqlDB, err := sql.Open("sqlite3", file)
+	defer closeDB(sqlDB)
+	require.Nil(t, err)
+
+	// set up table manually for POC check. Query is more exciting and writes are harder
+	// NOTE: Oof... "Bitempur-izing" an existing table almost 100% will need to create a side table for it
+	// becuase we will be taking the natural key and no longer making it a unique primary key
+	_, err = sqlDB.Exec(`
+		CREATE TABLE balances (
+			id TEXT NOT NULL, 				-- PK of the base table
+			type TEXT NOT NULL,
+			balance REAL NOT NULL,
+			is_active BOOLEAN NOT NULL,
+
+			__bt_id TEXT PRIMARY KEY, 		-- dang... forgot that this definitely needs a side table because of PK
+			__bt_tx_time_start TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			__bt_tx_time_end TIMESTAMP NULL,
+			__bt_valid_time_start TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			__bt_valid_time_end TIMESTAMP NULL
+		);
+	`)
+	require.Nil(t, err)
+
+	insert := func(id, balanceType string, balance int, isActive bool, txTimeStart time.Time, txEndTime *time.Time,
+		validTimeStart time.Time, validEndTime *time.Time) {
+		_, err = sqlDB.Exec(`
+			INSERT INTO balances
+			(
+				id,
+				type,
+				balance,
+				is_active,
+				__bt_id,
+				__bt_tx_time_start,
+				__bt_tx_time_end,
+				__bt_valid_time_start,
+				__bt_valid_time_end
+			)
+			VALUES
+			(
+				?,
+				?,
+				?,
+				?,
+				?,
+				?,
+				?,
+				?,
+				?
+			);
+		`,
+			id,
+			balanceType,
+			balance,
+			isActive,
+			uuid.New().String(),
+			txTimeStart,
+			txEndTime,
+			validTimeStart,
+			validEndTime,
+		)
+		require.Nil(t, err)
+	}
+
+	t1 := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := t1.AddDate(0, 0, 1)
+	t3 := t1.AddDate(0, 0, 2)
+	insert("alice/balance", "checking", 100, true, t1, &t3, t1, nil) // alice: checking 100 active
+	insert("alice/balance", "checking", 100, true, t3, nil, t1, &t3) // at t3, updated account to 200
+	insert("alice/balance", "checking", 200, true, t3, nil, t3, nil) //
+	insert("bob/balance", "savings", 100, true, t1, &t2, t1, nil)    // bob: savings 100 active
+	insert("bob/balance", "savings", 200, true, t2, nil, t1, nil)    // at t2, realize it was 200 the entire time
+	insert("carol/balance", "checking", 0, false, t1, &t2, t1, nil)  // carol: checking 0 inactive
+	insert("carol/balance", "checking", 0, false, t2, &t3, t1, &t2)  // at t2, add 100, reactivate account
+	insert("carol/balance", "checking", 100, true, t2, &t3, t2, nil) //
+	insert("carol/balance", "checking", 10, true, t3, nil, t1, &t3)  // at t3, oh no. realized it was re-actived but amount was wrong. it's 100 now
+	insert("carol/balance", "checking", 100, true, t3, nil, t3, nil) //
+
+	tableName := "balances"
+	db, err := NewTableDB(sqlDB, tableName, "id")
+	require.Nil(t, err)
+
+	_ = db
+	// s := squirrel.Select("*").From("balances")
+	// rows, err := db.Select(s)
+
+	rows, err := sqlDB.Query("SELECT * FROM balances")
+	require.Nil(t, err)
+	defer rows.Close()
+
+	var out []map[string]interface{}
+
+	cols, err := rows.Columns()
+	require.Nil(t, err)
+
+	for rows.Next() {
+		rowMap, err := scanToMap(rows, cols)
+		require.Nil(t, err)
+		out = append(out, rowMap)
+	}
+	if err = rows.Err(); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(toJSON(out))
+}
+
+// scanToMap scans a SQL row with a dynamic list of columns into a map
+func scanToMap(row *sql.Rows, cols []string) (map[string]interface{}, error) {
+	out := map[string]interface{}{}
+	fields := make([]interface{}, len(cols))
+	fieldPtrs := make([]interface{}, len(cols))
+	for i := range fields {
+		fieldPtrs[i] = &fields[i]
+	}
+	for i, col := range cols {
+		out[col] = &fieldPtrs[i]
+	}
+
+	if err := row.Scan(fieldPtrs...); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// do not nil point exception on defer
+func closeDB(db *sql.DB) {
+	if db != nil {
+		_ = db.Close()
+	}
+}
+
+//nolint:unused,deadcode // debug
+func toJSON(v interface{}) string {
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}

--- a/sql/doc.go
+++ b/sql/doc.go
@@ -1,4 +1,4 @@
 // Package sql implements a SQL-backed, SQL-queryable, bitemporal database.
 // This implements the key-value oriented interface of bitempura.DB and provides SQL querying.
-// WARN: WIP
+// WARNING: WIP. this implementation is experimental.
 package sql

--- a/sql/doc.go
+++ b/sql/doc.go
@@ -1,0 +1,4 @@
+// Package sql implements a SQL-backed, SQL-queryable, bitemporal database.
+// This implements the key-value oriented interface of bitempura.DB and provides SQL querying.
+// WARN: WIP
+package sql


### PR DESCRIPTION
`sql` implements a SQL-backed, SQL-queryable, bitemporal database. This implements the key-value oriented interface of bitempura.DB and provides SQL querying.

There is a new interface in `sql` with 1 major addition
```
// Select executes a SQL query (as of optional valid and transaction times).
Select(query squirrel.SelectBuilder, opts ...bt.ReadOpt) (*sql.Rows, error)
```

#### Example time traveling SQL query
```
s := squirrel.Select("type", "SUM(balance)").
    From("balances").
    GroupBy("type").
    OrderBy("SUM(balance) DESC")
rows, err := db.Select(s, bt.AsOfValidTime(t3), bt.AsOfTransactionTime(t2))
```

Current explorations optimizing for easiness and speed. squirrel for query building and sqlite for test db.

#### Status
* No support for setting up SQL tables
* All SQL DB functions are unimplemented
* Decide if scoping the sql.DB around a single table makes sense
* Interface changes?
    * Still need to decide what to do about versioning information + public interfaces
    * Consider just promoting a separate interface. KV interface and SQL interface should feel different