### PR TITLE
implement Get for SQL DB

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,14 +12,14 @@
     - [x] Show issue with race detector
     - [x] Actually run race detector in build
 - [ ] SQL backed implementation
-    - [ ] Get
+    - [x] Get
     - [ ] List
     - [ ] Set
     - [ ] Delete
     - [ ] History API?
         - [ ] ReadOpt's for History
     - [x] SQL querying
-    - [ ] support composite PKs
+    - [ ] support composite PKs, non-string PKs
 - [x] Exported DB test harness
 - [ ] Exported ReadOpt and WriteOpt handling
 - [ ] bitempur-ize existing SQL table

--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,7 @@
     - [ ] History API?
         - [ ] ReadOpt's for History
     - [x] SQL querying
+    - [ ] support composite PKs
 - [x] Exported DB test harness
 - [ ] Exported ReadOpt and WriteOpt handling
 - [ ] bitempur-ize existing SQL table

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 - [x] Split out in-memory implementation
 - [x] Thread safe writes
     - [x] Show issue with race detector
-    - [ ] Actually run race detector in build
+    - [x] Actually run race detector in build
 - [ ] SQL backed implementation
     - [ ] Get
     - [ ] List
@@ -19,8 +19,8 @@
     - [ ] History API?
         - [ ] ReadOpt's for History
     - [x] SQL querying
+- [x] Exported DB test harness
 - [ ] Exported ReadOpt and WriteOpt handling
-- [ ] Exported DB test harness
 - [ ] bitempur-ize existing SQL table
 - [ ] Visualizations. Interactive?
 - [ ] Performance/memory usage benchmarking

--- a/dbtest/test.go
+++ b/dbtest/test.go
@@ -32,7 +32,7 @@ func mustParseTime(layout, value string) time.Time {
 }
 
 // TestGet tests the Get function. dbFn must return a DB under test with the VersionedKV's stored in the database.
-func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
+func TestGet(t *testing.T, oldValue, newValue Value, dbFn func(kvs []*VersionedKV) (DB, error)) {
 	type fixtures struct {
 		name string
 		// make sure structs isolated between tests while doing in-mem mutations
@@ -50,7 +50,7 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
 					ValidTimeEnd:   nil,
-					Value:          "Old",
+					Value:          oldValue,
 				},
 			}
 		},
@@ -66,7 +66,7 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
 					ValidTimeEnd:   &t3,
-					Value:          "Old",
+					Value:          oldValue,
 				},
 			}
 		},
@@ -83,7 +83,7 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					TxTimeEnd:      &t3,
 					ValidTimeStart: t1,
 					ValidTimeEnd:   nil,
-					Value:          "Old",
+					Value:          oldValue,
 				},
 				{
 					Key:            "A",
@@ -91,7 +91,7 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
 					ValidTimeEnd:   &t3,
-					Value:          "Old",
+					Value:          oldValue,
 				},
 				{
 					Key:            "A",
@@ -99,7 +99,7 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					TxTimeEnd:      nil,
 					ValidTimeStart: t3,
 					ValidTimeEnd:   nil,
-					Value:          "New",
+					Value:          newValue,
 				},
 			}
 		},
@@ -114,7 +114,7 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					TxTimeEnd:      &t3,
 					ValidTimeStart: t1,
 					ValidTimeEnd:   nil,
-					Value:          "Old",
+					Value:          oldValue,
 				},
 				{
 					Key:            "A",
@@ -122,7 +122,7 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					TxTimeEnd:      nil,
 					ValidTimeStart: t1,
 					ValidTimeEnd:   &t3,
-					Value:          "Old",
+					Value:          oldValue,
 				},
 			}
 		},
@@ -160,7 +160,7 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 				{
 					desc:        "found - default as of times",
 					key:         "A",
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 				{
 					desc:              "not found - as of valid time T before valid time start",
@@ -178,25 +178,25 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					desc:        "found - as of valid time T in range",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfValidTime(t2)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 				{
 					desc:        "found - as of tx time T in range",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfTransactionTime(t2)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 				{
 					desc:        "found - as of valid time T in range (inclusive)",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfValidTime(t1)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 				{
 					desc:        "found - as of tx time T in range (inclusive)",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfTransactionTime(t1)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 			},
 		},
@@ -207,7 +207,7 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					desc:        "found - as of valid and tx time T in range",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfValidTime(t2), AsOfTransactionTime(t2)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 				// valid time end range
 				{
@@ -235,25 +235,25 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 				{
 					desc:        "found - default as of times",
 					key:         "A",
-					expectValue: "New",
+					expectValue: newValue,
 				},
 				{
 					desc:        "as of tx time now, as of valid time before update",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfValidTime(t1)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 				{
 					desc:        "as of tx time before update, as of valid time now",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfTransactionTime(t1)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 				{
 					desc:        "as of tx time before update, as of valid time before update",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfValidTime(t1), AsOfTransactionTime(t1)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 			},
 		},
@@ -269,19 +269,19 @@ func TestGet(t *testing.T, dbFn func(kvs []*VersionedKV) (DB, error)) {
 					desc:        "as of tx time now, as of valid time before update",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfValidTime(t1)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 				{
 					desc:        "as of tx time before update, as of valid time now",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfTransactionTime(t1)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 				{
 					desc:        "as of tx time before update, as of valid time before update",
 					key:         "A",
 					readOpts:    []ReadOpt{AsOfValidTime(t1), AsOfTransactionTime(t1)},
-					expectValue: "Old",
+					expectValue: oldValue,
 				},
 			},
 		},

--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -178,8 +178,9 @@ func TestConstructor(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	dbtest.TestGet(t, "OLD", "NEW", func(kvs []*VersionedKV) (DB, error) {
-		return memory.NewDB(memory.WithVersionedKVs(kvs))
+	dbtest.TestGet(t, "OLD", "NEW", func(kvs []*VersionedKV) (DB, func(), error) {
+		db, err := memory.NewDB(memory.WithVersionedKVs(kvs))
+		return db, func() {}, err
 	})
 }
 

--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -178,7 +178,7 @@ func TestConstructor(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	dbtest.TestGet(t, func(kvs []*VersionedKV) (DB, error) {
+	dbtest.TestGet(t, "OLD", "NEW", func(kvs []*VersionedKV) (DB, error) {
 		return memory.NewDB(memory.WithVersionedKVs(kvs))
 	})
 }

--- a/sql/scan.go
+++ b/sql/scan.go
@@ -1,0 +1,136 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	bt "github.com/elh/bitempura"
+)
+
+// ScanToVersionedKVs generically scans SQL rows into a slice of VersionedKV's. Caller should defer rows.Close() but
+// does not need to call rows.Err()
+func ScanToVersionedKVs(pkColumnName string, rows *sql.Rows) ([]*bt.VersionedKV, error) {
+	maps, err := ScanToMaps(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*bt.VersionedKV, len(maps))
+	for i, m := range maps {
+		keyI, ok := m[pkColumnName]
+		if !ok {
+			return nil, fmt.Errorf("missing pk column %s", pkColumnName)
+		}
+		key, ok := keyI.(string)
+		if !ok {
+			return nil, fmt.Errorf("key is not of type string")
+		}
+
+		txTimeStartI, ok := m["__bt_tx_time_start"]
+		if !ok {
+			return nil, fmt.Errorf("missing __bt_tx_time_start column")
+		}
+		txTimeStart, ok := txTimeStartI.(time.Time)
+		if !ok {
+			return nil, fmt.Errorf("__bt_tx_time_start value is not of type time.Time")
+		}
+		var txTimeEnd time.Time
+		txTimeEndI, ok := m["__bt_tx_time_end"]
+		if !ok {
+			return nil, fmt.Errorf("missing __bt_tx_time_end column")
+		}
+		if txTimeEndI != nil {
+			txTimeEnd, ok = txTimeEndI.(time.Time)
+			if !ok {
+				return nil, fmt.Errorf("__bt_tx_time_end value is not of type *time.Time (sql.NullTime)")
+			}
+		}
+
+		validTimeStartI, ok := m["__bt_valid_time_start"]
+		if !ok {
+			return nil, fmt.Errorf("missing __bt_valid_time_start column")
+		}
+		validTimeStart, ok := validTimeStartI.(time.Time)
+		if !ok {
+			return nil, fmt.Errorf("__bt_valid_time_start value is not of type time.Time")
+		}
+		var validTimeEnd time.Time
+		validTimeEndI, ok := m["__bt_valid_time_end"]
+		if !ok {
+			return nil, fmt.Errorf("missing __bt_valid_time_end column")
+		}
+		if validTimeEndI != nil {
+			validTimeEnd, ok = validTimeEndI.(time.Time)
+			if !ok {
+				return nil, fmt.Errorf("__bt_valid_time_end value is not of type *time.Time (sql.NullTime)")
+			}
+		}
+
+		val := map[string]interface{}{}
+		for k, v := range m {
+			if k != pkColumnName &&
+				k != "__bt_id" &&
+				k != "__bt_tx_time_start" &&
+				k != "__bt_tx_time_end" &&
+				k != "__bt_valid_time_start" &&
+				k != "__bt_valid_time_end" {
+				val[k] = v
+			}
+		}
+		kv := &bt.VersionedKV{
+			Key:            key,
+			Value:          val,
+			TxTimeStart:    txTimeStart,
+			TxTimeEnd:      toTimePtr(txTimeEnd),
+			ValidTimeStart: validTimeStart,
+			ValidTimeEnd:   toTimePtr(validTimeEnd),
+		}
+		out[i] = kv
+	}
+	return out, nil
+}
+
+func toTimePtr(t time.Time) *time.Time {
+	return &t
+}
+
+// ScanToMaps generically scans SQL rows into a slice of maps with columns as map keys. Caller should defer
+// rows.Close() but does not need to call rows.Err()
+func ScanToMaps(rows *sql.Rows) ([]map[string]interface{}, error) {
+	var out []map[string]interface{}
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		rowMap, err := scanToMap(rows, cols)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rowMap)
+	}
+	if err = rows.Err(); err != nil {
+		panic(err)
+	}
+	return out, nil
+}
+
+func scanToMap(row *sql.Rows, cols []string) (map[string]interface{}, error) {
+	fields := make([]interface{}, len(cols))
+	fieldPtrs := make([]interface{}, len(cols))
+	for i := range fields {
+		fieldPtrs[i] = &fields[i]
+	}
+
+	if err := row.Scan(fieldPtrs...); err != nil {
+		return nil, err
+	}
+
+	out := map[string]interface{}{}
+	for i, col := range cols {
+		out[col] = fields[i]
+	}
+	return out, nil
+}


### PR DESCRIPTION
* implement Get
* provide generic ScanToVersionedKVs and ScanToMaps helpers

Test improvements (pattern to be applied to other test changes)
* update TestGet to be parameterized by values appropriate for DB implementation type.
* update TestGet to take a dbFn that returns both the seeded db and a close function
* clean up test DB set up