### PR TITLE
Read from separate bitemporal state table

### DIFF
--- a/memory/db_test.go
+++ b/memory/db_test.go
@@ -188,8 +188,9 @@ func TestSet(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	dbtest.TestDelete(t, func(kvs []*VersionedKV, clock Clock) (DB, error) {
-		return memory.NewDB(memory.WithVersionedKVs(kvs), memory.WithClock(clock))
+	dbtest.TestDelete(t, "OLD", "NEW", func(kvs []*VersionedKV, clock Clock) (DB, func(), error) {
+		db, err := memory.NewDB(memory.WithVersionedKVs(kvs), memory.WithClock(clock))
+		return db, func() {}, err
 	})
 }
 


### PR DESCRIPTION
This is the most practical implementation due to complications around primary keys on the original table. Management of the state table and triggers is not implemented right now.

Triggers will be able to replicate all writes. When valid times are not specified, trigger should have a sane default behavior. We will need to identify relevant version records on the state table and and update (and add new ones) as needed.