### PR TITLE
set up memory/wasm. initial scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# wasm assets
+memory/wasm/assets/
+
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: error cp-wasm-exec build-wasm test-wasm
+
+error:
+	@echo "specify make target"
+	@exit 1
+
+# copy Go's wasm-exec to this project
+cp-wasm-exec:
+	mkdir -p memory/wasm/assets
+	cp $$(go env GOROOT)/misc/wasm/wasm_exec.js memory/wasm/assets/.
+
+# build memory/wasm and place in assets dir
+build-wasm:
+	mkdir -p memory/wasm/assets
+	(cd memory/wasm/main && GOOS=js GOARCH=wasm go build -o main.wasm && mv main.wasm ../assets/.)
+
+# starts up a local webserver for testing the wasm build
+test-wasm: build-wasm cp-wasm-exec
+	go run memory/wasm/test-server/main.go

--- a/memory/wasm/README.md
+++ b/memory/wasm/README.md
@@ -1,0 +1,7 @@
+# memory/wasm
+
+Provides a WebAssembly adapter for memory.DB.
+
+`main/` contains the registrations for `db.go` to WebAssembly. This is built into a gitignored `asserts/` dir.
+
+`make test-wasm` starts the `test-server/` server that serves the `.wasm` files for testing.

--- a/memory/wasm/db.go
+++ b/memory/wasm/db.go
@@ -1,0 +1,28 @@
+package wasm
+
+import (
+	"fmt"
+
+	"github.com/elh/bitempura"
+	"github.com/elh/bitempura/dbtest"
+	"github.com/elh/bitempura/memory"
+)
+
+var clock *dbtest.TestClock
+var db bitempura.DB
+
+func init() {
+	var err error
+	clock = &dbtest.TestClock{}
+	db, err = memory.NewDB(memory.WithClock(clock))
+	if err != nil {
+		fmt.Println("ERROR: failed to init db!")
+	}
+	_ = db
+
+	fmt.Println("INFO: db initialized!")
+}
+
+// TODO is just here to trigger the main import
+// TODO: remove this
+var TODO = "TODO: remove"

--- a/memory/wasm/doc.go
+++ b/memory/wasm/doc.go
@@ -1,0 +1,2 @@
+// Package wasm contains a WebAssembly adapter for memory.DB
+package wasm

--- a/memory/wasm/main/doc.go
+++ b/memory/wasm/main/doc.go
@@ -1,0 +1,2 @@
+// Package main is the main being built by memory/wasm
+package main

--- a/memory/wasm/main/main.go
+++ b/memory/wasm/main/main.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/elh/bitempura/memory/wasm"
+
+var _ = wasm.TODO // just trigger the init
+
+func main() {
+	c := make(chan struct{})
+	// TODO: register functions
+	<-c
+}

--- a/memory/wasm/test-server/index.html
+++ b/memory/wasm/test-server/index.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <script src="assets/wasm_exec.js"></script>
+    <script>
+        // polyfill
+        if (!WebAssembly.instantiateStreaming) {
+          WebAssembly.instantiateStreaming = async (resp, importObject) => {
+            const source = await (await resp).arrayBuffer();
+            return await WebAssembly.instantiate(source, importObject);
+          };
+        }
+
+        const go = new Go();
+        (async() => {
+          await WebAssembly
+            .instantiateStreaming(fetch("assets/main.wasm"), go.importObject)
+            .then((result) => {
+                go.run(result.instance);
+            });
+        })();
+    </script>
+</head>
+<body></body>
+</html>
+

--- a/memory/wasm/test-server/main.go
+++ b/memory/wasm/test-server/main.go
@@ -1,0 +1,19 @@
+// Package main starts up a local webserver for testing the wasm build
+package main
+
+import (
+	"net/http"
+)
+
+const (
+	appPort = "8080"
+)
+
+func main() {
+	http.Handle("/", http.FileServer(http.Dir("./memory/wasm/test-server")))
+	http.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("./memory/wasm/assets"))))
+
+	if err := http.ListenAndServe(":"+appPort, nil); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Provides a WebAssembly adapter for memory.DB.

`main/` contains the registrations for `db.go` to WebAssembly. This is built into a gitignored `asserts/` dir.

`make test-wasm` starts the `test-server/` server that serves the `.wasm` files for testing.