### PR TITLE
allow registation of on-change callback for Wasm db

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@
 - [x] Exported ReadOpt and WriteOpt handling. Separate provided inputs from resulting options for logging + SQL queries.
 - [ ] ReadOpt's for History
 - [ ] bitempur-ize existing SQL table
-- [ ] Visualizations. Interactive?
+- [x] Visualizations. Interactive? see bitempura-viz
 - [ ] Performance/memory usage benchmarking
     - [ ] Profiling
 

--- a/memory/wasm/README.md
+++ b/memory/wasm/README.md
@@ -2,7 +2,33 @@
 
 Provides compilation of `memory.DB` to WebAssembly.
 
-`main/` contains the registrations for callable functions and is built into the git-ignored `asserts/` dir. The working model for execution is that there is one global memory.DB. All functions are exported with the `bt_` prefix.
+`main/` contains the registrations for callable functions and is built into the git-ignored `asserts/` dir. The working model for execution is that there is one global memory.DB. `bt_Init` must be called before usage. All functions are exported with the `bt_` prefix.
+
+```
+// Init initializes the global Wasm DB. bt_Init must be called before usage.
+// arguments = [withClock: bool]
+
+// Get is the wasm adapter for DB.Get.
+// arguments = key: string, [as_of_valid_time: string (RFC 3339 datetime), as_of_transaction_time: string (RFC 3339 datetime)]
+
+// List is the wasm adapter for DB.List.
+// arguments = [as_of_valid_time: string (RFC 3339 datetime), as_of_transaction_time: string (RFC 3339 datetime)]
+
+// Set is the wasm adapter for DB.Set.
+// arguments = key: string, value: string (JSON string), [with_valid_time: string (RFC 3339 datetime), with_end_valid_time: string (RFC 3339 datetime)]
+
+// Delete is the wasm adapter for DB.Delete.
+// arguments = key: string, [with_valid_time: string (RFC 3339 datetime), with_end_valid_time: string (RFC 3339 datetime)]
+
+// History is the wasm adapter for DB.History.
+// arguments = key: string
+
+// OnChange allows the user to register a callback function to be called when the database changes.
+// arguments = fn: function (arity=0)
+
+// SetNow is the wasm adapter for dbtest.TestClock.SetNow. SetNow can only be called if DB was bt.Init-ed with a clock.
+// arguments = now: string (RFC 3339 datetime)
+```
 
 ### Testing
 

--- a/memory/wasm/db.go
+++ b/memory/wasm/db.go
@@ -19,26 +19,50 @@ var db bitempura.DB
 var clock *dbtest.TestClock
 var onChangeFn *js.Value
 
-func init() {
-	var err error
-	clock = &dbtest.TestClock{}
-	db, err = memory.NewDB(memory.WithClock(clock))
+// Init initializes the global Wasm DB. bt_Init must be called before usage.
+// arguments = [withClock: bool]
+func Init(this js.Value, inputs []js.Value) interface{} {
+	err := initDB(inputs)
 	if err != nil {
-		fmt.Printf("ERROR: failed to init db: %v\n", err)
-		return
+		fmt.Printf("ERROR: %v\n", err)
+	}
+	return nil
+}
+
+func initDB(inputs []js.Value) error {
+	var withClock bool
+	if len(inputs) > 0 {
+		if inputs[0].Type() != js.TypeBoolean {
+			return fmt.Errorf("withClock must be type bool")
+		}
+		withClock = inputs[0].Bool()
 	}
 
-	// initialize now for test clock
-	if err := clock.SetNow(time.Now().UTC()); err != nil {
-		fmt.Printf("ERROR: failed to set up clock: %v\n", err)
-		return
+	var opts []memory.DBOpt
+	if withClock {
+		clock = &dbtest.TestClock{}
+		// initialize now for manually controlled clock
+		if err := clock.SetNow(time.Now().UTC()); err != nil {
+			return err
+		}
+		opts = append(opts, memory.WithClock(clock))
 	}
-	fmt.Println("bt db initialized.")
+
+	var err error
+	db, err = memory.NewDB(opts...)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Get is the wasm adapter for DB.Get.
 // arguments = key: string, [as_of_valid_time: string (RFC 3339 datetime), as_of_transaction_time: string (RFC 3339 datetime)]
 func Get(this js.Value, inputs []js.Value) interface{} {
+	if db == nil {
+		fmt.Println("ERROR: db is not initialized. call bt_Init")
+		return nil
+	}
 	res, err := get(inputs)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
@@ -100,6 +124,10 @@ func get(inputs []js.Value) (interface{}, error) {
 // List is the wasm adapter for DB.List.
 // arguments = [as_of_valid_time: string (RFC 3339 datetime), as_of_transaction_time: string (RFC 3339 datetime)]
 func List(this js.Value, inputs []js.Value) interface{} {
+	if db == nil {
+		fmt.Println("ERROR: db is not initialized. call bt_Init")
+		return nil
+	}
 	res, err := list(inputs)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
@@ -151,6 +179,10 @@ func list(inputs []js.Value) (interface{}, error) {
 // Set is the wasm adapter for DB.Set.
 // arguments = key: string, value: string (JSON string), [with_valid_time: string (RFC 3339 datetime), with_end_valid_time: string (RFC 3339 datetime)]
 func Set(this js.Value, inputs []js.Value) interface{} {
+	if db == nil {
+		fmt.Println("ERROR: db is not initialized. call bt_Init")
+		return nil
+	}
 	err := set(inputs)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
@@ -221,6 +253,10 @@ func set(inputs []js.Value) error {
 // Delete is the wasm adapter for DB.Delete.
 // arguments = key: string, [with_valid_time: string (RFC 3339 datetime), with_end_valid_time: string (RFC 3339 datetime)]
 func Delete(this js.Value, inputs []js.Value) interface{} {
+	if db == nil {
+		fmt.Println("ERROR: db is not initialized. call bt_Init")
+		return nil
+	}
 	err := delete(inputs)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
@@ -282,6 +318,10 @@ func delete(inputs []js.Value) error {
 // History is the wasm adapter for DB.History.
 // arguments = key: string
 func History(this js.Value, inputs []js.Value) interface{} {
+	if db == nil {
+		fmt.Println("ERROR: db is not initialized. call bt_Init")
+		return nil
+	}
 	res, err := history(inputs)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
@@ -312,9 +352,37 @@ func history(inputs []js.Value) (interface{}, error) {
 	return res, nil
 }
 
-// SetNow is the wasm adapter for dbtest.TestClock.SetNow.
+// OnChange allows the user to register a callback function to be called when the database changes.
+// arguments = fn: function (arity=0)
+func OnChange(this js.Value, inputs []js.Value) interface{} {
+	err := onChange(inputs)
+	if err != nil {
+		fmt.Printf("ERROR: %v\n", err)
+	}
+	return nil
+}
+
+func onChange(inputs []js.Value) error {
+	{
+		if len(inputs) < 1 {
+			return fmt.Errorf("fn is required")
+		}
+		if inputs[0].Type() != js.TypeFunction {
+			return fmt.Errorf("fn must be type function")
+		}
+		onChangeFn = &inputs[0]
+	}
+
+	return nil
+}
+
+// SetNow is the wasm adapter for dbtest.TestClock.SetNow. SetNow can only be called if DB was Init-ed with a clock.
 // arguments = now: string (RFC 3339 datetime)
 func SetNow(this js.Value, inputs []js.Value) interface{} {
+	if clock == nil {
+		fmt.Println("ERROR: clock is not initialized. bt_Init must be called with withClock=true")
+		return nil
+	}
 	err := setNow(inputs)
 	if err != nil {
 		fmt.Printf("ERROR: %v\n", err)
@@ -341,30 +409,6 @@ func setNow(inputs []js.Value) error {
 	if err := clock.SetNow(now); err != nil {
 		return fmt.Errorf("failed to set now: %v\n", err)
 	}
-	return nil
-}
-
-// OnChange allows the user to register a callback function to be called when the database changes.
-// arguments = fn: function (arity=0)
-func OnChange(this js.Value, inputs []js.Value) interface{} {
-	err := onChange(inputs)
-	if err != nil {
-		fmt.Printf("ERROR: %v\n", err)
-	}
-	return nil
-}
-
-func onChange(inputs []js.Value) error {
-	{
-		if len(inputs) < 1 {
-			return fmt.Errorf("fn is required")
-		}
-		if inputs[0].Type() != js.TypeFunction {
-			return fmt.Errorf("fn must be type function")
-		}
-		onChangeFn = &inputs[0]
-	}
-
 	return nil
 }
 

--- a/memory/wasm/main/main.go
+++ b/memory/wasm/main/main.go
@@ -10,9 +10,11 @@ import (
 )
 
 // All functions are exported with the "bt_" prefix.
-// The working model for execution in Wasm is that there is one global memory.DB.
+// The working model for execution in Wasm is that there is one global memory.DB. bt_Init must be called before usage.
 func main() {
 	c := make(chan struct{})
+	// init (and re-init)
+	js.Global().Set("bt_Init", js.FuncOf(wasm.Init))
 	// db functions
 	js.Global().Set("bt_Get", js.FuncOf(wasm.Get))
 	js.Global().Set("bt_List", js.FuncOf(wasm.List))
@@ -20,7 +22,7 @@ func main() {
 	js.Global().Set("bt_Delete", js.FuncOf(wasm.Delete))
 	js.Global().Set("bt_History", js.FuncOf(wasm.History))
 	// helpers
-	js.Global().Set("bt_SetNow", js.FuncOf(wasm.SetNow))
 	js.Global().Set("bt_OnChange", js.FuncOf(wasm.OnChange))
+	js.Global().Set("bt_SetNow", js.FuncOf(wasm.SetNow))
 	<-c
 }

--- a/memory/wasm/main/main.go
+++ b/memory/wasm/main/main.go
@@ -13,11 +13,14 @@ import (
 // The working model for execution in Wasm is that there is one global memory.DB.
 func main() {
 	c := make(chan struct{})
+	// db functions
 	js.Global().Set("bt_Get", js.FuncOf(wasm.Get))
 	js.Global().Set("bt_List", js.FuncOf(wasm.List))
 	js.Global().Set("bt_Set", js.FuncOf(wasm.Set))
 	js.Global().Set("bt_Delete", js.FuncOf(wasm.Delete))
 	js.Global().Set("bt_History", js.FuncOf(wasm.History))
+	// helpers
 	js.Global().Set("bt_SetNow", js.FuncOf(wasm.SetNow))
+	js.Global().Set("bt_OnChange", js.FuncOf(wasm.OnChange))
 	<-c
 }


### PR DESCRIPTION
also require an explicit `bt_Init` call. still just using a single global instance